### PR TITLE
Add params to response decorator

### DIFF
--- a/backend/src/common/decorators/response.decorator.ts
+++ b/backend/src/common/decorators/response.decorator.ts
@@ -1,5 +1,10 @@
 import { SetMetadata } from '@nestjs/common';
 
+export interface ResponseMessageOptions {
+  okMessage: string;
+  emptyArrayMessage?: string;
+}
+
 export const ResponseMessageKey = 'RESPONSE_MESSAGE_KEY';
-export const ResponseMessage = (message: string) =>
-  SetMetadata(ResponseMessageKey, message);
+export const ResponseMessage = (options: ResponseMessageOptions) =>
+  SetMetadata(ResponseMessageKey, options);

--- a/backend/src/common/interceptors/formatresponse.interceptor.ts
+++ b/backend/src/common/interceptors/formatresponse.interceptor.ts
@@ -7,7 +7,10 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Observable, map } from 'rxjs';
-import { ResponseMessageKey } from '@common/decorators/response.decorator';
+import {
+  ResponseMessageKey,
+  ResponseMessageOptions,
+} from '@common/decorators/response.decorator';
 import { FormatedResponse } from '@common/interfaces/formatedresponses.interface';
 
 @Injectable()
@@ -20,18 +23,27 @@ export class FormatResponseInterceptor<T = any>
     context: ExecutionContext,
     next: CallHandler,
   ): Observable<FormatedResponse<T>> {
-    const responseMessage =
-      this.reflector.get<string>(ResponseMessageKey, context.getHandler()) ??
-      '';
+    const responseMessageOptions: ResponseMessageOptions =
+      this.reflector.get<ResponseMessageOptions>(
+        ResponseMessageKey,
+        context.getHandler(),
+      ) ?? { okMessage: '' };
 
     return next.handle().pipe(
       map((data) => {
         const statusCode = context.switchToHttp().getResponse().statusCode;
+
+        let message = responseMessageOptions.okMessage;
+
+        if (Array.isArray(data) && data.length === 0) {
+          message = responseMessageOptions.emptyArrayMessage;
+        }
+
         return {
           success:
             statusCode >= HttpStatus.OK && statusCode < HttpStatus.BAD_REQUEST,
           data,
-          message: responseMessage,
+          message: message,
           statusCode,
         };
       }),

--- a/backend/src/modules/categories/infrastructure/controllers/categories.controller.spec.ts
+++ b/backend/src/modules/categories/infrastructure/controllers/categories.controller.spec.ts
@@ -12,7 +12,10 @@ import { CategoriesService } from '../../application/services/categories.service
 import { CreateCategoryDto } from '../dto/create-category.dto';
 import { UpdateCategoryDto } from '../dto/update-category.dto';
 import { Category } from '../../domain/entity/category.entity';
-import { ResponseMessageKey } from '@common/decorators/response.decorator';
+import {
+  ResponseMessageKey,
+  ResponseMessageOptions,
+} from '@common/decorators/response.decorator';
 import { CATEGORIES_RESPONSES } from '../../common/categories.responses';
 import { CategoryPresenter } from '../presenters/category.presenter';
 import { CategoriesUseCase } from '@modules/categories/application/usecases/categories.usecase';
@@ -65,13 +68,16 @@ describe('CategoriesController', () => {
     });
 
     it('should have the corresponding response message', () => {
-      const responseMessage = reflector.get<string>(
-        ResponseMessageKey,
-        categoriesController.create,
-      );
+      const responseMessageOptions: ResponseMessageOptions =
+        reflector.get<ResponseMessageOptions>(
+          ResponseMessageKey,
+          categoriesController.create,
+        );
 
-      expect(responseMessage).toBeDefined();
-      expect(responseMessage).toBe(CATEGORIES_RESPONSES.CREATED);
+      expect(responseMessageOptions).toBeDefined();
+      expect(responseMessageOptions).toEqual({
+        okMessage: CATEGORIES_RESPONSES.CREATED,
+      });
     });
 
     it('should create a category', async () => {
@@ -137,13 +143,16 @@ describe('CategoriesController', () => {
     });
 
     it('should have the corresponding response message', () => {
-      const responseMessage = reflector.get<string>(
-        ResponseMessageKey,
-        categoriesController.findAll,
-      );
+      const responseMessageOptions: ResponseMessageOptions =
+        reflector.get<ResponseMessageOptions>(
+          ResponseMessageKey,
+          categoriesController.findAll,
+        );
 
-      expect(responseMessage).toBeDefined();
-      expect(responseMessage).toBe(CATEGORIES_RESPONSES.FOUND_MANY);
+      expect(responseMessageOptions).toBeDefined();
+      expect(responseMessageOptions).toEqual({
+        okMessage: CATEGORIES_RESPONSES.FOUND_MANY,
+      });
     });
 
     it('should return an array of categories', async () => {
@@ -174,13 +183,16 @@ describe('CategoriesController', () => {
     });
 
     it('should have the corresponding response message', () => {
-      const responseMessage = reflector.get<string>(
-        ResponseMessageKey,
-        categoriesController.findOne,
-      );
+      const responseMessageOptions: ResponseMessageOptions =
+        reflector.get<ResponseMessageOptions>(
+          ResponseMessageKey,
+          categoriesController.findOne,
+        );
 
-      expect(responseMessage).toBeDefined();
-      expect(responseMessage).toBe(CATEGORIES_RESPONSES.FOUND_ONE);
+      expect(responseMessageOptions).toBeDefined();
+      expect(responseMessageOptions).toEqual({
+        okMessage: CATEGORIES_RESPONSES.FOUND_ONE,
+      });
     });
 
     it('should return a category', async () => {
@@ -224,13 +236,16 @@ describe('CategoriesController', () => {
     });
 
     it('should have the corresponding response message', () => {
-      const responseMessage = reflector.get<string>(
-        ResponseMessageKey,
-        categoriesController.update,
-      );
+      const responseMessageOptions: ResponseMessageOptions =
+        reflector.get<ResponseMessageOptions>(
+          ResponseMessageKey,
+          categoriesController.update,
+        );
 
-      expect(responseMessage).toBeDefined();
-      expect(responseMessage).toBe(CATEGORIES_RESPONSES.UPDATED);
+      expect(responseMessageOptions).toBeDefined();
+      expect(responseMessageOptions).toEqual({
+        okMessage: CATEGORIES_RESPONSES.UPDATED,
+      });
     });
 
     it('should update a category', async () => {
@@ -313,13 +328,16 @@ describe('CategoriesController', () => {
     });
 
     it('should have the corresponding response message', () => {
-      const responseMessage = reflector.get<string>(
-        ResponseMessageKey,
-        categoriesController.delete,
-      );
+      const responseMessageOptions: ResponseMessageOptions =
+        reflector.get<ResponseMessageOptions>(
+          ResponseMessageKey,
+          categoriesController.delete,
+        );
 
-      expect(responseMessage).toBeDefined();
-      expect(responseMessage).toBe(CATEGORIES_RESPONSES.DELETED);
+      expect(responseMessageOptions).toBeDefined();
+      expect(responseMessageOptions).toEqual({
+        okMessage: CATEGORIES_RESPONSES.DELETED,
+      });
     });
 
     it('should delete a category', async () => {
@@ -355,13 +373,17 @@ describe('CategoriesController', () => {
     });
 
     it('should have the corresponding response message', () => {
-      const responseMessage = reflector.get<string>(
-        ResponseMessageKey,
-        categoriesController.filter,
-      );
+      const responseMessageOptions: ResponseMessageOptions =
+        reflector.get<ResponseMessageOptions>(
+          ResponseMessageKey,
+          categoriesController.filter,
+        );
 
-      expect(responseMessage).toBeDefined();
-      expect(responseMessage).toBe(CATEGORIES_RESPONSES.FOUND_MANY);
+      expect(responseMessageOptions).toBeDefined();
+      expect(responseMessageOptions).toEqual({
+        okMessage: CATEGORIES_RESPONSES.FOUND_MANY,
+        emptyArrayMessage: CATEGORIES_RESPONSES.NOT_FOUND_MANY,
+      });
     });
 
     it('should return an array of categories', async () => {
@@ -428,13 +450,17 @@ describe('CategoriesController', () => {
     });
 
     it('should have the corresponding response message', () => {
-      const responseMessage = reflector.get<string>(
-        ResponseMessageKey,
-        categoriesController.search,
-      );
+      const responseMessageOptions: ResponseMessageOptions =
+        reflector.get<ResponseMessageOptions>(
+          ResponseMessageKey,
+          categoriesController.search,
+        );
 
-      expect(responseMessage).toBeDefined();
-      expect(responseMessage).toBe(CATEGORIES_RESPONSES.FOUND_MANY);
+      expect(responseMessageOptions).toBeDefined();
+      expect(responseMessageOptions).toEqual({
+        okMessage: CATEGORIES_RESPONSES.FOUND_MANY,
+        emptyArrayMessage: CATEGORIES_RESPONSES.NOT_FOUND_MANY,
+      });
     });
 
     it('should return an array of categories', async () => {

--- a/backend/src/modules/categories/infrastructure/controllers/categories.controller.ts
+++ b/backend/src/modules/categories/infrastructure/controllers/categories.controller.ts
@@ -58,7 +58,7 @@ export class CategoriesController {
     description: 'The request was wrongly made.',
   })
   @ApiBody({ type: CreateCategoryDto })
-  @ResponseMessage(CATEGORIES_RESPONSES.CREATED)
+  @ResponseMessage({ okMessage: CATEGORIES_RESPONSES.CREATED })
   async create(
     @Body() createCategoryDto: CreateCategoryDto,
   ): Promise<CategoryPresenter> {
@@ -101,7 +101,10 @@ export class CategoriesController {
     required: false,
     description: 'The keyword to search in the categories',
   })
-  @ResponseMessage(CATEGORIES_RESPONSES.FOUND_MANY)
+  @ResponseMessage({
+    okMessage: CATEGORIES_RESPONSES.FOUND_MANY,
+    emptyArrayMessage: CATEGORIES_RESPONSES.NOT_FOUND_MANY,
+  })
   search(@Query() params: SearchByKeywordParams): Promise<CategoryPresenter[]> {
     return this.categoriesSearchUseCase.searchCategoriesByKeyword(
       params.keyword,
@@ -136,7 +139,10 @@ export class CategoriesController {
     required: false,
     description: 'The active status of the category',
   })
-  @ResponseMessage(CATEGORIES_RESPONSES.FOUND_MANY)
+  @ResponseMessage({
+    okMessage: CATEGORIES_RESPONSES.FOUND_MANY,
+    emptyArrayMessage: CATEGORIES_RESPONSES.NOT_FOUND_MANY,
+  })
   filter(
     @Query() criteria: FilterCategoryByCriteriaParams,
   ): Promise<CategoryPresenter[]> {
@@ -166,7 +172,7 @@ export class CategoriesController {
     format: 'uuid',
     description: 'The ID of the category',
   })
-  @ResponseMessage(CATEGORIES_RESPONSES.FOUND_ONE)
+  @ResponseMessage({ okMessage: CATEGORIES_RESPONSES.FOUND_ONE })
   async findOne(
     @Param() params: FindOneCategoryParams,
   ): Promise<CategoryPresenter> {
@@ -185,7 +191,7 @@ export class CategoriesController {
     type: CategoryPresenter,
     isArray: true,
   })
-  @ResponseMessage(CATEGORIES_RESPONSES.FOUND_MANY)
+  @ResponseMessage({ okMessage: CATEGORIES_RESPONSES.FOUND_MANY })
   findAll(): Promise<CategoryPresenter[]> {
     return this.categoriesUseCase.getAllCategories();
   }
@@ -208,7 +214,7 @@ export class CategoriesController {
     description: 'The ID of the category',
   })
   @ApiBody({ type: UpdateCategoryDto })
-  @ResponseMessage(CATEGORIES_RESPONSES.UPDATED)
+  @ResponseMessage({ okMessage: CATEGORIES_RESPONSES.UPDATED })
   async update(
     @Param() params: UpdateCategoryParams,
     @Body() updateCategoryDto: UpdateCategoryDto,
@@ -248,7 +254,7 @@ export class CategoriesController {
     format: 'uuid',
     description: 'The ID of the category',
   })
-  @ResponseMessage(CATEGORIES_RESPONSES.DELETED)
+  @ResponseMessage({ okMessage: CATEGORIES_RESPONSES.DELETED })
   async delete(@Param() params: DeleteCategoryParams): Promise<void> {
     const result = await this.categoriesUseCase.deleteCategory(params.id);
 


### PR DESCRIPTION
# Description

Added params to response message decorator
Also:
* Adapted formatResponse and categories Controller to the change
* Added coverage test to FormatResponse test file

List any dependencies that are required for this change.

Fixes #47 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related Issues

N/A

## Additional Notes

N/A

## Screenshots

N/A

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Coverage Test for FormatResponse Interceptor

**Test Environment**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# All Submissions

Before filling out the fields of the pull request, please make sure you meet the following requirements

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules
